### PR TITLE
chore: include shared packages for supabase functions

### DIFF
--- a/supabase/functions/packages
+++ b/supabase/functions/packages
@@ -1,0 +1,1 @@
+../packages

--- a/supabase/functions/research-run/index.ts
+++ b/supabase/functions/research-run/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { fetchPaperBars } from "../../packages/execution/index.ts";
-import { sma, rsi, detectRegime } from "../../packages/strategy/index.ts";
+import { fetchPaperBars } from "../packages/execution/index.ts";
+import { sma, rsi, detectRegime } from "../packages/strategy/index.ts";
 
 /**
  * Research run generates a simple trade opportunity for a given symbol.

--- a/supabase/packages/execution/index.ts
+++ b/supabase/packages/execution/index.ts
@@ -1,0 +1,61 @@
+export function makeClientOrderId(tradeId: string, n=1){
+  return `${tradeId}-${n}`;
+}
+
+export interface OrderRequest {
+  symbol: string; side: 'buy'|'sell'; qty: number;
+  type: 'market'|'limit'|'stop'|'stop_limit';
+  limitPrice?: number; stopPrice?: number; tif?: 'day'|'ioc'|'fok';
+}
+
+async function alpacaFetch(path: string, opts: RequestInit){
+  const base = process.env.BROKER_BASE_URL || 'https://paper-api.alpaca.markets';
+  const headers = {
+    'APCA-API-KEY-ID': process.env.BROKER_KEY || '',
+    'APCA-API-SECRET-KEY': process.env.BROKER_SECRET || '',
+    ...(opts.headers || {})
+  } as Record<string, string>;
+  const res = await fetch(`${base}${path}`, { ...opts, headers });
+  if (!res.ok){
+    const text = await res.text();
+    throw new Error(`Alpaca error ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+export async function placePaperOrder(order: OrderRequest){
+  return alpacaFetch('/v2/orders', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      symbol: order.symbol,
+      side: order.side,
+      qty: order.qty,
+      type: order.type,
+      time_in_force: order.tif || 'day',
+      limit_price: order.limitPrice,
+      stop_price: order.stopPrice,
+    })
+  });
+}
+
+export interface Bar {
+  t: string; o: number; h: number; l: number; c: number; v: number;
+}
+
+export async function fetchPaperBars(symbol: string, timeframe='1D', limit=100): Promise<Bar[]>{
+  const base = process.env.BROKER_DATA_URL || 'https://data.alpaca.markets';
+  const res = await fetch(`${base}/v2/stocks/${symbol}/bars?timeframe=${timeframe}&limit=${limit}`, {
+    headers: {
+      'APCA-API-KEY-ID': process.env.BROKER_KEY || '',
+      'APCA-API-SECRET-KEY': process.env.BROKER_SECRET || ''
+    }
+  });
+  if (!res.ok){
+    const text = await res.text();
+    throw new Error(`Alpaca data error ${res.status}: ${text}`);
+  }
+  const json = await res.json();
+  return json.bars || [];
+}
+

--- a/supabase/packages/strategy/index.ts
+++ b/supabase/packages/strategy/index.ts
@@ -1,0 +1,35 @@
+export function sma(values: number[], period: number): number[] {
+  const out: number[] = [];
+  for (let i=0;i<values.length;i++){
+    if (i+1<period) { out.push(NaN); continue; }
+    const slice = values.slice(i+1-period, i+1);
+    out.push(slice.reduce((a,b)=>a+b,0)/period);
+  }
+  return out;
+}
+export function rsi(values: number[], period=14): number[] {
+  // simple RSI (placeholder)
+  const out: number[] = new Array(values.length).fill(NaN);
+  for (let i=period;i<values.length;i++){
+    let gains=0, losses=0;
+    for (let j=i-period+1;j<=i;j++){
+      const d = values[j]-values[j-1];
+      if (d>0) gains+=d; else losses-=d;
+    }
+    const rs = losses === 0 ? 100 : gains / (losses||1e-9);
+    out[i] = 100 - (100/(1+rs));
+  }
+  return out;
+}
+export function detectRegime(close: number[]): 'TREND'|'RANGE'|'HIGH_VOL'|'LOW_VOL' {
+  // toy regime: slope sign + stdev magnitude
+  const n = close.length;
+  if (n < 20) return 'RANGE';
+  const last20 = close.slice(-20);
+  const slope = last20[last20.length-1]-last20[0];
+  const mean = last20.reduce((a,b)=>a+b,0)/last20.length;
+  const stdev = Math.sqrt(last20.reduce((a,b)=>a+(b-mean)**2,0)/last20.length);
+  if (stdev > mean*0.02) return 'HIGH_VOL';
+  if (Math.abs(slope) < mean*0.002) return 'RANGE';
+  return 'TREND';
+}


### PR DESCRIPTION
## Summary
- copy execution and strategy packages into the supabase directory for function builds
- update research-run function imports to reference the new package locations

## Testing
- `pnpm test` (failed: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)
- `npx supabase functions deploy research-run` (failed: 403 Forbidden - GET https://registry.npmjs.org/supabase)


------
https://chatgpt.com/codex/tasks/task_e_6897dea655648324b0cfe5200ce4fcfc