### PR TITLE
feat: expand research and monitoring

### DIFF
--- a/apps/web/app/api/opportunities/[id]/approve/route.ts
+++ b/apps/web/app/api/opportunities/[id]/approve/route.ts
@@ -57,6 +57,11 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     status: 'FILLED',
   });
 
+  await client
+    .from('trade_opportunities')
+    .update({ status: 'APPROVED' })
+    .eq('id', params.id);
+
   if (idKey) {
     await client
       .from('idempotency_keys')

--- a/apps/web/app/api/opportunities/[id]/status/route.ts
+++ b/apps/web/app/api/opportunities/[id]/status/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabase } from '@lib/supabase';
+
+const VALID = ['PENDING_APPROVAL','APPROVED','REJECTED','EXPIRED'];
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const body = await req.json().catch(() => ({}));
+  const status: string | undefined = body.status;
+  if (!status || !VALID.includes(status)) {
+    return NextResponse.json({ ok: false, error: 'invalid status' }, { status: 400 });
+  }
+
+  const { error } = await supabase()
+    .from('trade_opportunities')
+    .update({ status })
+    .eq('id', params.id);
+  if (error) {
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/supabase/functions/monitor-open-trades/index.ts
+++ b/supabase/functions/monitor-open-trades/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { fetchPaperBars } from "../_shared/execution.ts";
 
 /**
  * Simple per-minute monitor for open trades.
@@ -21,7 +22,7 @@ serve(async (_req) => {
 
   const { data: trades, error } = await supabase
     .from("trades")
-    .select("id, opened_at")
+    .select("id, symbol, side, opportunity_id, opened_at")
     .eq("status", "OPEN");
   if (error) {
     return new Response(
@@ -30,17 +31,63 @@ serve(async (_req) => {
     );
   }
 
+  const { data: limits } = await supabase
+    .from("risk_limits")
+    .select("cap_type, value")
+    .eq("scope", "TRADE")
+    .eq("active", true);
+  const pctLimit = limits?.find((l) => l.cap_type === "PCT")?.value as
+    | number
+    | undefined;
+
   let closed = 0;
   const now = Date.now();
   const dayMs = 24 * 60 * 60 * 1000;
   for (const t of trades ?? []) {
     const opened = t.opened_at ? new Date(t.opened_at).getTime() : now;
-    if (now - opened > dayMs) {
+
+    const { data: opp } = await supabase
+      .from("trade_opportunities")
+      .select("entry_plan_json, stop_plan_json, take_profit_json")
+      .eq("id", t.opportunity_id)
+      .single();
+    const entry = opp?.entry_plan_json?.price ?? null;
+    const stop = opp?.stop_plan_json?.stop ?? null;
+    const target = opp?.take_profit_json?.tp ?? null;
+
+    let reason = "";
+    if (entry && stop && pctLimit) {
+      const riskPct =
+        t.side === "LONG"
+          ? ((entry - stop) / entry) * 100
+          : ((stop - entry) / entry) * 100;
+      if (riskPct > pctLimit) reason = "RISK";
+    }
+
+    if (!reason && stop !== null && target !== null) {
+      const bars = await fetchPaperBars(t.symbol, "1Min", 1);
+      const price = bars.at(-1)?.c;
+      if (price !== undefined) {
+        if (t.side === "LONG") {
+          if (price <= stop) reason = "STOP";
+          else if (price >= target) reason = "TARGET";
+        } else {
+          if (price >= stop) reason = "STOP";
+          else if (price <= target) reason = "TARGET";
+        }
+      }
+    }
+
+    if (!reason && now - opened > dayMs) {
+      reason = "TTL";
+    }
+
+    if (reason) {
       const { error: updErr } = await supabase
         .from("trades")
         .update({
           status: "CLOSED",
-          close_reason: "TTL",
+          close_reason: reason,
           closed_at: new Date().toISOString(),
         })
         .eq("id", t.id);

--- a/supabase/functions/research-run/index.ts
+++ b/supabase/functions/research-run/index.ts
@@ -3,6 +3,37 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { fetchPaperBars } from "../_shared/execution.ts";
 import { sma, rsi, detectRegime } from "../_shared/strategy.ts";
 
+async function generateAnalysis(symbol: string, smaVal: number, rsiVal: number, regime: string) {
+  const key = Deno.env.get("OPENAI_API_KEY");
+  const baseSummary = `Regime ${regime}; SMA20 ${smaVal.toFixed(2)}, RSI14 ${rsiVal.toFixed(2)}`;
+  if (!key) {
+    return { summary: baseSummary, risks: "High volatility" };
+  }
+  try {
+    const res = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${key}`,
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [{
+          role: "user",
+          content: `Given the following market data for ${symbol}: Regime ${regime}, SMA20 ${smaVal.toFixed(2)}, RSI14 ${rsiVal.toFixed(2)}. Provide a short trading summary and key risks.`,
+        }],
+        max_tokens: 120,
+      }),
+    });
+    const json = await res.json();
+    const text = json.choices?.[0]?.message?.content ?? "";
+    const [summary, risks] = text.split("Risks:");
+    return { summary: summary?.trim() || baseSummary, risks: risks?.trim() || "High volatility" };
+  } catch (_) {
+    return { summary: baseSummary, risks: "High volatility" };
+  }
+}
+
 /**
  * Research run generates a simple trade opportunity for a given symbol.
  *
@@ -12,17 +43,10 @@ import { sma, rsi, detectRegime } from "../_shared/strategy.ts";
  */
 serve(async (req) => {
   const { searchParams } = new URL(req.url);
-  const symbol = searchParams.get("symbol") ?? "AAPL";
   const timeframe = searchParams.get("timeframe") ?? "1D";
-
-  const bars = await fetchPaperBars(symbol, timeframe);
-  const closes = bars.map((b) => b.c);
-  const sma20 = sma(closes, 20);
-  const rsi14 = rsi(closes, 14);
-  const regime = detectRegime(closes);
-  const last = bars[bars.length - 1];
-
-  const aiSummary = `Regime ${regime}; SMA20 ${sma20.at(-1)?.toFixed(2)}, RSI14 ${rsi14.at(-1)?.toFixed(2)}`;
+  const symbolsParam =
+    searchParams.get("symbols") ?? Deno.env.get("RESEARCH_SYMBOLS") ?? "AAPL";
+  const symbols = symbolsParam.split(",").map((s) => s.trim()).filter(Boolean);
 
   const url = Deno.env.get("SUPABASE_URL");
   const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
@@ -34,31 +58,49 @@ serve(async (req) => {
   }
   const supabase = createClient(url, key);
 
-  const { data, error } = await supabase
-    .from("trade_opportunities")
-    .insert({
-      symbol,
-      side: "LONG",
-      timeframe: timeframe.toLowerCase(),
-      entry_plan_json: { price: last.c },
-      stop_plan_json: { stop: last.l },
-      take_profit_json: { tp: last.h },
-      risk_summary: `RSI ${rsi14.at(-1)?.toFixed(2)}`,
-      expected_return: 1,
-      confidence: 0.5,
-      ai_summary: aiSummary,
-      ai_risks: "High volatility",
-    })
-    .select("id")
-    .single();
-  if (error) {
-    return new Response(
-      JSON.stringify({ ok: false, error: error.message }),
-      { status: 500, headers: { "content-type": "application/json" } },
-    );
+  const results: { symbol: string; id: string }[] = [];
+  for (const symbol of symbols) {
+    try {
+      const bars = await fetchPaperBars(symbol, timeframe);
+      if (!bars.length) continue;
+      const closes = bars.map((b) => b.c);
+      const sma20 = sma(closes, 20);
+      const rsi14 = rsi(closes, 14);
+      const regime = detectRegime(closes);
+      const last = bars[bars.length - 1];
+      const ai = await generateAnalysis(
+        symbol,
+        sma20.at(-1) ?? 0,
+        rsi14.at(-1) ?? 0,
+        regime,
+      );
+
+      const { data, error } = await supabase
+        .from("trade_opportunities")
+        .insert({
+          symbol,
+          side: "LONG",
+          timeframe: timeframe.toLowerCase(),
+          entry_plan_json: { price: last.c },
+          stop_plan_json: { stop: last.l },
+          take_profit_json: { tp: last.h },
+          risk_summary: `RSI ${rsi14.at(-1)?.toFixed(2)}`,
+          expected_return: 1,
+          confidence: 0.5,
+          ai_summary: ai.summary,
+          ai_risks: ai.risks,
+        })
+        .select("id")
+        .single();
+      if (!error && data) {
+        results.push({ symbol, id: data.id });
+      }
+    } catch (_) {
+      continue;
+    }
   }
 
-  return new Response(JSON.stringify({ ok: true, opportunityId: data.id }), {
+  return new Response(JSON.stringify({ ok: true, opportunities: results }), {
     headers: { "content-type": "application/json" },
   });
 });


### PR DESCRIPTION
## Summary
- extend research run to generate opportunities for configurable symbol lists and AI summaries
- add status update endpoint and mark opportunities approved after trade creation
- monitor open trades for stop-loss, targets and risk limits

## Testing
- `pnpm test` *(fails: Request was cancelled - Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_6897e5c2de3c8324b09c314cc8639763