### PR TITLE
feat: add strategy filters and risk sizing

### DIFF
--- a/packages/risk/index.ts
+++ b/packages/risk/index.ts
@@ -4,6 +4,26 @@ export function sizeByVol(equityUSD: number, atrUSD: number, maxRiskPct=0.01){
   const qty = Math.floor(maxRiskUSD / atrUSD);
   return Math.max(qty, 0);
 }
+
+export function sizeWithRiskCaps(
+  equityUSD: number,
+  atrUSD: number,
+  dayRiskUSD: number,
+  weekRiskUSD: number,
+  perTradePct = 0.01,
+  dayPct = 0.02,
+  weekPct = 0.05,
+) {
+  // base position by volatility
+  const baseQty = sizeByVol(equityUSD, atrUSD, perTradePct);
+  if (atrUSD <= 0) return 0;
+  // remaining risk capital for day and week
+  const remainingDay = Math.max(equityUSD * dayPct - dayRiskUSD, 0);
+  const remainingWeek = Math.max(equityUSD * weekPct - weekRiskUSD, 0);
+  const dayQty = Math.floor(remainingDay / atrUSD);
+  const weekQty = Math.floor(remainingWeek / atrUSD);
+  return Math.max(Math.min(baseQty, dayQty, weekQty), 0);
+}
 export function shouldTightenTrail(rMultiple: number){
   // tighten on discrete thresholds
   return rMultiple >= 0.5; // placeholder

--- a/packages/strategy/index.ts
+++ b/packages/strategy/index.ts
@@ -1,3 +1,5 @@
+import { sizeWithRiskCaps } from '../risk';
+
 export function sma(values: number[], period: number): number[] {
   const out: number[] = [];
   for (let i=0;i<values.length;i++){
@@ -20,6 +22,90 @@ export function rsi(values: number[], period=14): number[] {
     out[i] = 100 - (100/(1+rs));
   }
   return out;
+}
+
+export function bollinger(values: number[], period=20, mult=2){
+  const mid = sma(values, period);
+  const upper: number[] = [];
+  const lower: number[] = [];
+  for (let i=0;i<values.length;i++){
+    if (i+1<period){
+      upper.push(NaN); lower.push(NaN); continue;
+    }
+    const slice = values.slice(i+1-period, i+1);
+    const mean = mid[i];
+    const stdev = Math.sqrt(slice.reduce((a,b)=>a+(b-mean)**2,0)/period);
+    upper[i] = mean + stdev*mult;
+    lower[i] = mean - stdev*mult;
+  }
+  return { mid, upper, lower };
+}
+
+export function smaCrossSignal(prices: number[], shortP=10, longP=20): number[]{
+  const short = sma(prices, shortP);
+  const long = sma(prices, longP);
+  const out: number[] = new Array(prices.length).fill(0);
+  for (let i=1;i<prices.length;i++){
+    if (isNaN(short[i]) || isNaN(long[i]) || isNaN(short[i-1]) || isNaN(long[i-1])) continue;
+    const prevDiff = short[i-1]-long[i-1];
+    const diff = short[i]-long[i];
+    if (prevDiff<=0 && diff>0) out[i]=1;
+    else if (prevDiff>=0 && diff<0) out[i]=-1;
+  }
+  return out;
+}
+
+export function meanReversionSignal(close: number[], rsiPeriod=14, bbPeriod=20, bbMult=2){
+  const bb = bollinger(close, bbPeriod, bbMult);
+  const r = rsi(close, rsiPeriod);
+  return close.map((c,i)=>{
+    if (c<bb.lower[i] && r[i]<30) return 1;
+    if (c>bb.upper[i] && r[i]>70) return -1;
+    return 0;
+  });
+}
+
+export function atr(high: number[], low: number[], close: number[], period=14){
+  const tr: number[] = [];
+  for (let i=0;i<close.length;i++){
+    const prevClose = i>0?close[i-1]:close[i];
+    const highLow = high[i]-low[i];
+    const highClose = Math.abs(high[i]-prevClose);
+    const lowClose = Math.abs(low[i]-prevClose);
+    tr.push(Math.max(highLow, highClose, lowClose));
+  }
+  return sma(tr, period);
+}
+
+function percentileRank(values: number[], value: number){
+  const sorted = values.slice().sort((a,b)=>a-b);
+  let count=0;
+  for (const v of sorted){ if (v<=value) count++; }
+  return (count / sorted.length) * 100;
+}
+
+export function atrPercentileFilter(high: number[], low: number[], close: number[], atrPeriod=14, lookback=100, threshold=80){
+  const atrVals = atr(high, low, close, atrPeriod);
+  const recent = atrVals.slice(-lookback);
+  const last = atrVals[atrVals.length-1];
+  const pct = percentileRank(recent, last);
+  return pct >= threshold;
+}
+
+export function transactionCost(qty: number, commissionPerUnit: number){
+  return qty * commissionPerUnit;
+}
+
+export function slippage(price: number, qty: number, bps: number){
+  return price * qty * (bps/10000);
+}
+
+export function netEdge(grossEdge: number, price: number, qty: number, commissionPerUnit: number, slippageBps: number){
+  return grossEdge - transactionCost(qty, commissionPerUnit) - slippage(price, qty, slippageBps);
+}
+
+export function calcTradeSize(equityUSD: number, atrUSD: number, dayRiskUSD: number, weekRiskUSD: number){
+  return sizeWithRiskCaps(equityUSD, atrUSD, dayRiskUSD, weekRiskUSD);
 }
 export function detectRegime(close: number[]): 'TREND'|'RANGE'|'HIGH_VOL'|'LOW_VOL' {
   // toy regime: slope sign + stdev magnitude


### PR DESCRIPTION
## Summary
- add SMA-cross momentum and Bollinger/RSI mean-reversion signals
- add ATR percentile filters and cost/slippage net edge utilities
- add risk sizing utility capped per-trade/day/week