### PR TITLE
feat: add audit logging and market data hashing

### DIFF
--- a/packages/core/audit.ts
+++ b/packages/core/audit.ts
@@ -1,0 +1,43 @@
+import { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+export interface AuditEntry {
+  actor_type: string;
+  actor_id?: string;
+  action: string;
+  entity_type?: string;
+  entity_id?: string;
+  payload_json?: Record<string, unknown>;
+}
+
+async function computeHash(input: string) {
+  const data = new TextEncoder().encode(input);
+  const buf = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function insertAuditLog(
+  supabase: SupabaseClient,
+  entry: AuditEntry,
+) {
+  const { data: last } = await supabase
+    .from("audit_log")
+    .select("hash")
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const prevHash = last?.hash ?? "";
+  const hash = await computeHash(prevHash + JSON.stringify(entry));
+
+  const { error } = await supabase.from("audit_log").insert({
+    ...entry,
+    hash,
+  });
+  if (error) {
+    throw new Error(error.message);
+  }
+  return hash;
+}
+

--- a/packages/execution/index.ts
+++ b/packages/execution/index.ts
@@ -1,3 +1,6 @@
+import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { insertAuditLog } from "../core/audit.ts";
+
 export function makeClientOrderId(tradeId: string, n=1){
   return `${tradeId}-${n}`;
 }
@@ -23,8 +26,26 @@ async function alpacaFetch(path: string, opts: RequestInit){
   return res.json();
 }
 
-export async function placePaperOrder(order: OrderRequest){
-  return alpacaFetch('/v2/orders', {
+export async function placePaperOrder(
+  order: OrderRequest,
+  supabase?: SupabaseClient,
+){
+  const client = supabase || (() => {
+    const url = Deno.env.get('SUPABASE_URL');
+    const key = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+    return url && key ? createClient(url, key) : undefined;
+  })();
+
+  if (client) {
+    await insertAuditLog(client, {
+      actor_type: 'SYSTEM',
+      action: 'PLACE_ORDER',
+      entity_type: 'order',
+      payload_json: order,
+    });
+  }
+
+  const res = await alpacaFetch('/v2/orders', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -37,6 +58,16 @@ export async function placePaperOrder(order: OrderRequest){
       stop_price: order.stopPrice,
     })
   });
+
+  if (client) {
+    await insertAuditLog(client, {
+      actor_type: 'SYSTEM',
+      action: 'ORDER_RESPONSE',
+      entity_type: 'order',
+      payload_json: res,
+    });
+  }
+  return res;
 }
 
 export interface Bar {

--- a/supabase/functions/_shared/audit.ts
+++ b/supabase/functions/_shared/audit.ts
@@ -1,0 +1,43 @@
+import { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+export interface AuditEntry {
+  actor_type: string;
+  actor_id?: string;
+  action: string;
+  entity_type?: string;
+  entity_id?: string;
+  payload_json?: Record<string, unknown>;
+}
+
+async function computeHash(input: string) {
+  const data = new TextEncoder().encode(input);
+  const hashBuf = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hashBuf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function insertAuditLog(
+  supabase: SupabaseClient,
+  entry: AuditEntry,
+) {
+  const { data: last } = await supabase
+    .from("audit_log")
+    .select("hash")
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const prevHash = last?.hash ?? "";
+  const hash = await computeHash(prevHash + JSON.stringify(entry));
+
+  const { error } = await supabase.from("audit_log").insert({
+    ...entry,
+    hash,
+  });
+  if (error) {
+    throw new Error(error.message);
+  }
+  return hash;
+}
+

--- a/supabase/functions/_shared/execution.ts
+++ b/supabase/functions/_shared/execution.ts
@@ -1,3 +1,6 @@
+import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { insertAuditLog } from "./audit.ts";
+
 export function makeClientOrderId(tradeId: string, n = 1) {
   return `${tradeId}-${n}`;
 }
@@ -27,8 +30,28 @@ async function alpacaFetch(path: string, opts: RequestInit) {
   return res.json();
 }
 
-export async function placePaperOrder(order: OrderRequest) {
-  return alpacaFetch('/v2/orders', {
+export async function placePaperOrder(
+  order: OrderRequest,
+  supabase?: SupabaseClient,
+) {
+  const client =
+    supabase ||
+    (() => {
+      const url = Deno.env.get('SUPABASE_URL');
+      const key = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+      return url && key ? createClient(url, key) : undefined;
+    })();
+
+  if (client) {
+    await insertAuditLog(client, {
+      actor_type: 'SYSTEM',
+      action: 'PLACE_ORDER',
+      entity_type: 'order',
+      payload_json: order,
+    });
+  }
+
+  const res = await alpacaFetch('/v2/orders', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -41,6 +64,16 @@ export async function placePaperOrder(order: OrderRequest) {
       stop_price: order.stopPrice,
     }),
   });
+
+  if (client) {
+    await insertAuditLog(client, {
+      actor_type: 'SYSTEM',
+      action: 'ORDER_RESPONSE',
+      entity_type: 'order',
+      payload_json: res,
+    });
+  }
+  return res;
 }
 
 export interface Bar {

--- a/supabase/functions/research-run/index.ts
+++ b/supabase/functions/research-run/index.ts
@@ -1,7 +1,55 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { fetchPaperBars } from "../_shared/execution.ts";
+import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { fetchPaperBars, Bar } from "../_shared/execution.ts";
 import { sma, rsi, detectRegime } from "../_shared/strategy.ts";
+import { insertAuditLog } from "../_shared/audit.ts";
+
+async function hashBar(b: Bar) {
+  const str = `${b.t}|${b.o}|${b.h}|${b.l}|${b.c}|${b.v}`;
+  const buf = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(str),
+  );
+  return Array.from(new Uint8Array(buf))
+    .map((n) => n.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function saveBars(
+  supabase: SupabaseClient,
+  symbol: string,
+  timeframe: string,
+  bars: Bar[],
+) {
+  for (const b of bars) {
+    const hash = await hashBar(b);
+    const { data: existing } = await supabase
+      .from("market_data_pti")
+      .select("hash, revision")
+      .eq("symbol", symbol)
+      .eq("timeframe", timeframe.toLowerCase())
+      .eq("ts", b.t)
+      .order("revision", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (existing && existing.hash === hash) continue;
+
+    const revision = existing ? existing.revision + 1 : 0;
+    await supabase.from("market_data_pti").insert({
+      symbol,
+      timeframe: timeframe.toLowerCase(),
+      ts: b.t,
+      o: b.o,
+      h: b.h,
+      l: b.l,
+      c: b.c,
+      v: b.v,
+      revision,
+      hash,
+    });
+  }
+}
 
 /**
  * Research run generates a simple trade opportunity for a given symbol.
@@ -14,7 +62,8 @@ serve(async (req) => {
   const { searchParams } = new URL(req.url);
   const symbol = searchParams.get("symbol") ?? "AAPL";
   const timeframe = searchParams.get("timeframe") ?? "1D";
-
+  const modelId = searchParams.get("model_id");
+  const modelVersion = searchParams.get("model_version");
   const bars = await fetchPaperBars(symbol, timeframe);
   const closes = bars.map((b) => b.c);
   const sma20 = sma(closes, 20);
@@ -34,6 +83,21 @@ serve(async (req) => {
   }
   const supabase = createClient(url, key);
 
+  await insertAuditLog(supabase, {
+    actor_type: "SYSTEM",
+    action: "RESEARCH_RUN",
+    entity_type: "research",
+    payload_json: { symbol, timeframe, model_id: modelId, model_version: modelVersion },
+  });
+
+  await saveBars(supabase, symbol, timeframe, bars);
+  await insertAuditLog(supabase, {
+    actor_type: "SYSTEM",
+    action: "MARKET_DATA_SAVED",
+    entity_type: "market_data",
+    payload_json: { symbol, timeframe, count: bars.length },
+  });
+
   const { data, error } = await supabase
     .from("trade_opportunities")
     .insert({
@@ -48,6 +112,8 @@ serve(async (req) => {
       confidence: 0.5,
       ai_summary: aiSummary,
       ai_risks: "High volatility",
+      model_id: modelId,
+      model_version: modelVersion,
     })
     .select("id")
     .single();
@@ -57,6 +123,14 @@ serve(async (req) => {
       { status: 500, headers: { "content-type": "application/json" } },
     );
   }
+
+  await insertAuditLog(supabase, {
+    actor_type: "SYSTEM",
+    action: "OPPORTUNITY_CREATED",
+    entity_type: "trade_opportunity",
+    entity_id: data.id,
+    payload_json: { symbol, timeframe, model_id: modelId, model_version: modelVersion },
+  });
 
   return new Response(JSON.stringify({ ok: true, opportunityId: data.id }), {
     headers: { "content-type": "application/json" },

--- a/supabase/migrations/0001_init.sql
+++ b/supabase/migrations/0001_init.sql
@@ -36,6 +36,8 @@ create table if not exists trade_opportunities (
   id uuid primary key default gen_random_uuid(),
   report_id uuid,
   strategy_id uuid,
+  model_id uuid,
+  model_version text,
   symbol text not null,
   side text check (side in ('LONG','SHORT')) not null,
   timeframe text not null,

--- a/supabase/packages/core/audit.ts
+++ b/supabase/packages/core/audit.ts
@@ -1,0 +1,40 @@
+import { createHash } from "crypto";
+import { SupabaseClient } from "@supabase/supabase-js";
+
+export interface AuditEntry {
+  actor_type: string;
+  actor_id?: string;
+  action: string;
+  entity_type?: string;
+  entity_id?: string;
+  payload_json?: Record<string, unknown>;
+}
+
+function computeHash(input: string) {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+export async function insertAuditLog(
+  supabase: SupabaseClient,
+  entry: AuditEntry,
+) {
+  const { data: last } = await supabase
+    .from("audit_log")
+    .select("hash")
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const prevHash = last?.hash ?? "";
+  const hash = computeHash(prevHash + JSON.stringify(entry));
+
+  const { error } = await supabase.from("audit_log").insert({
+    ...entry,
+    hash,
+  });
+  if (error) {
+    throw new Error(error.message);
+  }
+  return hash;
+}
+

--- a/supabase/packages/execution/index.ts
+++ b/supabase/packages/execution/index.ts
@@ -1,3 +1,6 @@
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { insertAuditLog } from "../core/audit.ts";
+
 export function makeClientOrderId(tradeId: string, n=1){
   return `${tradeId}-${n}`;
 }
@@ -23,8 +26,26 @@ async function alpacaFetch(path: string, opts: RequestInit){
   return res.json();
 }
 
-export async function placePaperOrder(order: OrderRequest){
-  return alpacaFetch('/v2/orders', {
+export async function placePaperOrder(
+  order: OrderRequest,
+  supabase?: SupabaseClient,
+){
+  const client = supabase || (() => {
+    const url = process.env.SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    return url && key ? createClient(url, key) : undefined;
+  })();
+
+  if (client) {
+    await insertAuditLog(client, {
+      actor_type: 'SYSTEM',
+      action: 'PLACE_ORDER',
+      entity_type: 'order',
+      payload_json: order,
+    });
+  }
+
+  const res = await alpacaFetch('/v2/orders', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -37,6 +58,16 @@ export async function placePaperOrder(order: OrderRequest){
       stop_price: order.stopPrice,
     })
   });
+
+  if (client) {
+    await insertAuditLog(client, {
+      actor_type: 'SYSTEM',
+      action: 'ORDER_RESPONSE',
+      entity_type: 'order',
+      payload_json: res,
+    });
+  }
+  return res;
 }
 
 export interface Bar {


### PR DESCRIPTION
## Summary
- create reusable audit log utility with hash chaining
- log research actions and trade executions using the audit log
- record market data revisions and model metadata in research