### PR TITLE
feat(web): supabase dashboards and trade pages

### DIFF
--- a/apps/web/app/(routes)/dashboard/page.tsx
+++ b/apps/web/app/(routes)/dashboard/page.tsx
@@ -1,1 +1,66 @@
-export default function Page(){ return (<div><h2>Dashboard</h2><p>PNL, open trades, alerts, kill switch here.</p></div>); }
+'use client';
+
+import { useEffect, useState } from 'react';
+import { supabase } from '@lib/supabase';
+
+type Trade = {
+  id: string;
+  symbol: string;
+  side: string;
+  qty: number;
+};
+
+export default function Page() {
+  const client = supabase();
+  const [pnl, setPnl] = useState<number | null>(null);
+  const [openTrades, setOpenTrades] = useState<Trade[]>([]);
+  const [killMsg, setKillMsg] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: pnlData } = await client.rpc('portfolio_pnl').catch(() => ({ data: 0 }));
+      setPnl(typeof pnlData === 'number' ? pnlData : 0);
+
+      const { data: tradesData } = await client
+        .from('trades')
+        .select('id, symbol, side, qty')
+        .eq('status', 'OPEN')
+        .order('opened_at', { ascending: false });
+      setOpenTrades(tradesData ?? []);
+    };
+    load();
+  }, [client]);
+
+  const triggerKillSwitch = async () => {
+    setKillMsg('Sending...');
+    try {
+      const res = await fetch('/api/kill-switch', { method: 'POST' });
+      setKillMsg(res.ok ? 'Kill switch triggered' : 'Failed to send');
+    } catch {
+      setKillMsg('Failed to send');
+    }
+  };
+
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      <div style={{ marginBottom: 16 }}>
+        <strong>PnL:</strong> {pnl ?? '...'}
+      </div>
+      <div style={{ marginBottom: 16 }}>
+        <h3>Open Trades</h3>
+        {openTrades.length === 0 && <p>No open trades.</p>}
+        <ul>
+          {openTrades.map((t) => (
+            <li key={t.id}>
+              {t.symbol} {t.side} x{t.qty}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <button onClick={triggerKillSwitch}>Kill Switch</button>
+      {killMsg && <p>{killMsg}</p>}
+    </div>
+  );
+}
+

--- a/apps/web/app/(routes)/opportunities/page.tsx
+++ b/apps/web/app/(routes)/opportunities/page.tsx
@@ -1,12 +1,69 @@
-import Link from 'next/link';
-export default function Page(){
+'use client';
+
+import { useEffect, useState } from 'react';
+import { supabase } from '@lib/supabase';
+
+type Opportunity = {
+  id: string;
+  symbol: string;
+  side: string;
+  ai_summary: string | null;
+};
+
+export default function Page() {
+  const client = supabase();
+  const [opps, setOpps] = useState<Opportunity[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data } = await client
+        .from('trade_opportunities')
+        .select('id, symbol, side, ai_summary')
+        .eq('status', 'PENDING_APPROVAL')
+        .order('created_at', { ascending: false });
+      setOpps(data ?? []);
+      setLoading(false);
+    };
+    load();
+  }, [client]);
+
+  const approve = async (id: string) => {
+    await fetch(`/api/opportunities/${id}/approve`, { method: 'POST' });
+    setOpps((prev) => prev.filter((o) => o.id !== id));
+  };
+
+  const reject = async (id: string) => {
+    await client
+      .from('trade_opportunities')
+      .update({ status: 'REJECTED' })
+      .eq('id', id);
+    setOpps((prev) => prev.filter((o) => o.id !== id));
+  };
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <div>
       <h2>Opportunities</h2>
-      <p>List of research-created trade opportunities with AI summaries.</p>
+      {opps.length === 0 && <p>No pending opportunities.</p>}
       <ul>
-        <li><Link href="/opportunities?id=sample">Sample Opportunity</Link></li>
+        {opps.map((o) => (
+          <li key={o.id} style={{ marginBottom: 16 }}>
+            <div>
+              <strong>{o.symbol}</strong> {o.side}
+            </div>
+            {o.ai_summary && <p>{o.ai_summary}</p>}
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button onClick={() => approve(o.id)}>Approve</button>
+              <button onClick={() => reject(o.id)}>Reject</button>
+            </div>
+          </li>
+        ))}
       </ul>
     </div>
   );
 }
+

--- a/apps/web/app/(routes)/trades/page.tsx
+++ b/apps/web/app/(routes)/trades/page.tsx
@@ -1,1 +1,56 @@
-export default function Page(){ return (<div><h2>Trades</h2><p>Live and historical trades.</p></div>); }
+'use client';
+
+import { useEffect, useState } from 'react';
+import { supabase } from '@lib/supabase';
+
+type Trade = {
+  id: string;
+  symbol: string;
+  side: string;
+  qty: number;
+  status: string;
+};
+
+export default function Page() {
+  const client = supabase();
+  const [trades, setTrades] = useState<Trade[]>([]);
+
+  const load = async () => {
+    const { data } = await client
+      .from('trades')
+      .select('id, symbol, side, qty, status')
+      .order('opened_at', { ascending: false });
+    setTrades(data ?? []);
+  };
+
+  useEffect(() => {
+    load();
+    const channel = client
+      .channel('trades-history')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'trades' },
+        () => {
+          load();
+        }
+      )
+      .subscribe();
+    return () => {
+      client.removeChannel(channel);
+    };
+  }, [client]);
+
+  return (
+    <div>
+      <h2>Trades</h2>
+      <ul>
+        {trades.map((t) => (
+          <li key={t.id}>
+            {t.symbol} {t.side} x{t.qty} - {t.status}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- display pending opportunities from Supabase with approval and rejection actions
- show portfolio PnL and open trades on dashboard with backend kill switch
- render trade history and live status updates

## Testing
- `pnpm lint` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm test` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_6897e5d3b8588324afe4464a527cafb2