### PR TITLE
feat: apply risk caps on trade approvals

### DIFF
--- a/apps/web/app/api/opportunities/[id]/approve/route.ts
+++ b/apps/web/app/api/opportunities/[id]/approve/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabase } from '@lib/supabase';
 import { placeAndTrackOrder } from '@execution/index';
+import { sizeWithRiskCaps } from '@risk/index';
+import { insertAuditLog } from '@core/audit';
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   const idKey = req.headers.get('Idempotency-Key');
@@ -25,11 +27,39 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
 
   const { data: opp, error: oppErr } = await client
     .from('trade_opportunities')
-    .select('symbol, side, timeframe')
+    .select('symbol, side, timeframe, entry_plan_json, stop_plan_json')
     .eq('id', params.id)
     .single();
   if (oppErr || !opp) {
     return NextResponse.json({ ok: false, error: 'opportunity not found' }, { status: 404 });
+  }
+
+  const entryPrice = Number(opp.entry_plan_json?.price ?? 0);
+  const stopPrice = Number(opp.stop_plan_json?.stop ?? 0);
+  const atrUSD = Math.abs(entryPrice - stopPrice);
+
+  const baseEquity = Number(process.env.STARTING_EQUITY_USD ?? '100000');
+  const [{ data: dayPnl }, { data: weekPnl }, { data: portfolioPnl }] =
+    await Promise.all([
+      client.rpc('day_pnl'),
+      client.rpc('week_pnl'),
+      client.rpc('portfolio_pnl'),
+    ]);
+  const dayRiskUSD = Math.abs(Number(dayPnl) || 0);
+  const weekRiskUSD = Math.abs(Number(weekPnl) || 0);
+  const equityUSD = baseEquity + (Number(portfolioPnl) || 0);
+
+  const allowedQty = sizeWithRiskCaps(
+    equityUSD,
+    atrUSD,
+    dayRiskUSD,
+    weekRiskUSD,
+  );
+  if (qty > allowedQty) {
+    return NextResponse.json(
+      { ok: false, error: 'qty exceeds risk cap', cap: allowedQty },
+      { status: 400 },
+    );
   }
 
   const { data: trade, error: tradeErr } = await client
@@ -45,6 +75,21 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   if (tradeErr) {
     return NextResponse.json({ ok: false, error: tradeErr.message }, { status: 500 });
   }
+
+  await insertAuditLog(client, {
+    actor_type: 'SYSTEM',
+    action: 'APPROVE_TRADE',
+    entity_type: 'trade',
+    entity_id: trade.id,
+    payload_json: {
+      qty,
+      allowedQty,
+      equityUSD,
+      atrUSD,
+      dayRiskUSD,
+      weekRiskUSD,
+    },
+  });
 
   await client
     .from('trade_opportunities')


### PR DESCRIPTION
## Summary
- enforce sizeWithRiskCaps when approving trade opportunities
- fetch daily/weekly PnL to derive risk usage and reject oversize requests
- log approved trade size and risk context in audit trail

## Testing
- `node --test apps/web/tests/integration.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6898ad42cb98832484e4ff2482d51ab2