### PR TITLE
Adjust daily research cron and document manual updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,15 @@
      supabase functions deploy monitor-open-trades
      ```
 
-5. **Cron**  
-   - Configure Supabase Scheduler/pg_cron for daily/hourly research and per-minute monitoring (see SQL comments at top of migration).
+5. **Cron**
+   - Daily research: `30 13 * * 1-5` (60 min before U.S. market open)
+   - Optional hourly research: `0 * * * *` calls `rpc_start_research('1h')`
+   - If jobs already exist, re-run the migration or unschedule/reschedule manually:
+     ```sql
+     select cron.unschedule('daily_research');
+     select cron.schedule('daily_research', '30 13 * * 1-5', $$ select rpc_start_research('1d'); $$);
+     select cron.schedule('hourly_research', '0 * * * *', $$ select rpc_start_research('1h'); $$); -- optional
+     ```
 
 ## Notes
 - Orders are **paper** by default (stubbed broker). Broker credentials are loaded from Azure Key Vault and rotated quarterly.

--- a/supabase/migrations/0002_pg_cron.sql
+++ b/supabase/migrations/0002_pg_cron.sql
@@ -4,11 +4,18 @@
 -- Ensure pg_cron extension is available
 create extension if not exists pg_cron;
 
--- Run daily research roughly 90 minutes before the U.S. market opens
+-- Run daily research roughly 60 minutes before the U.S. market opens
 select cron.schedule(
   'daily_research',
-  '0 13 * * 1-5',
+  '30 13 * * 1-5',
   $$ select rpc_start_research('1d'); $$
+);
+
+-- Optional: run hourly research at the top of each hour
+select cron.schedule(
+  'hourly_research',
+  '0 * * * *',
+  $$ select rpc_start_research('1h'); $$
 );
 
 -- Monitor open trades during the regular session (14:30-21:00 GMT)


### PR DESCRIPTION
## Summary
- Run daily research cron one hour before market open
- Add optional hourly research cron job
- Document manual cron job updates in README

## Testing
- `pnpm lint` *(fails: RequestAbortedError [AbortError]: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm test` *(fails: RequestAbortedError [AbortError]: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_6898b635087483249f27fcdf22dac281