### PR TITLE
feat(web): add kill switch API route

### DIFF
--- a/apps/web/app/api/kill-switch/route.ts
+++ b/apps/web/app/api/kill-switch/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+export async function POST() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    return NextResponse.json(
+      { ok: false, error: 'missing env' },
+      { status: 500 },
+    );
+  }
+
+  const client = createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const { data, error } = await client.functions.invoke('kill-switch', { body: {} });
+  if (error) {
+    return NextResponse.json(
+      { ok: false, error: error.message },
+      { status: 500 },
+    );
+  }
+  return NextResponse.json(data);
+}


### PR DESCRIPTION
## Summary
- add `/api/kill-switch` route invoking Supabase Edge Function with service-role key

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6898c87565288324b9b277a8065123c5