### PR TITLE
feat: enforce correlation group exposure limits

### DIFF
--- a/supabase/migrations/0004_trades_correlation_group.sql
+++ b/supabase/migrations/0004_trades_correlation_group.sql
@@ -1,0 +1,3 @@
+-- 0004_trades_correlation_group.sql
+-- Add correlation_group column to trades
+alter table trades add column if not exists correlation_group text;


### PR DESCRIPTION
## Summary
- track correlation groups for trades
- monitor open trades aggregates exposure by group and enforces group USD limits