### PR TITLE
fix: handle env in edge function

### DIFF
--- a/supabase/packages/execution/index.ts
+++ b/supabase/packages/execution/index.ts
@@ -1,7 +1,17 @@
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { insertAuditLog } from "../core/audit.ts";
 
-export function makeClientOrderId(tradeId: string, n=1){
+function getEnv(name: string): string | undefined {
+  if (typeof Deno !== "undefined" && typeof Deno.env?.get === "function") {
+    return Deno.env.get(name) ?? undefined;
+  }
+  if (typeof process !== "undefined") {
+    return (process as any).env?.[name];
+  }
+  return undefined;
+}
+
+export function makeClientOrderId(tradeId: string, n = 1) {
   return `${tradeId}-${n}`;
 }
 
@@ -11,19 +21,29 @@ export interface OrderRequest {
   limitPrice?: number; stopPrice?: number; tif?: 'day'|'ioc'|'fok';
 }
 
-async function alpacaFetch(path: string, opts: RequestInit){
-  const base = process.env.BROKER_BASE_URL || 'https://paper-api.alpaca.markets/v2';
+async function alpacaFetch(path: string, opts: RequestInit) {
+  const base =
+    getEnv("BROKER_BASE_URL") ?? "https://paper-api.alpaca.markets/v2";
   const headers = {
-    'APCA-API-KEY-ID': process.env.BROKER_KEY,
-    'APCA-API-SECRET-KEY': process.env.BROKER_SECRET,
-    ...(opts.headers || {})
+    "APCA-API-KEY-ID": getEnv("BROKER_KEY") ?? "",
+    "APCA-API-SECRET-KEY": getEnv("BROKER_SECRET") ?? "",
+    ...(opts.headers || {}),
   } as Record<string, string>;
   const res = await fetch(`${base}${path}`, { ...opts, headers });
-  if (!res.ok){
+  if (!res.ok) {
     const text = await res.text();
     throw new Error(`Alpaca error ${res.status}: ${text}`);
   }
   return res.json();
+}
+
+async function getBrokerCreds() {
+  const key = getEnv("BROKER_KEY");
+  const secret = getEnv("BROKER_SECRET");
+  if (!key || !secret) {
+    throw new Error("Missing broker credentials");
+  }
+  return { key, secret };
 }
 
 export async function placePaperOrder(
@@ -74,16 +94,23 @@ export interface Bar {
   t: string; o: number; h: number; l: number; c: number; v: number;
 }
 
-export async function fetchPaperBars(symbol: string, timeframe='1D', limit=100): Promise<Bar[]>{
-  const base = 'https://data.alpaca.markets/v2';
-  const { key, secret } = await creds();
-  const res = await fetch(`${base}/stocks/${symbol}/bars?timeframe=${timeframe}&limit=${limit}`, {
-    headers: {
-      'APCA-API-KEY-ID': key,
-      'APCA-API-SECRET-KEY': secret
-    }
-  });
-  if (!res.ok){
+export async function fetchPaperBars(
+  symbol: string,
+  timeframe = "1D",
+  limit = 100,
+): Promise<Bar[]> {
+  const base = "https://data.alpaca.markets/v2";
+  const { key, secret } = await getBrokerCreds();
+  const res = await fetch(
+    `${base}/stocks/${symbol}/bars?timeframe=${timeframe}&limit=${limit}`,
+    {
+      headers: {
+        "APCA-API-KEY-ID": key,
+        "APCA-API-SECRET-KEY": secret,
+      },
+    },
+  );
+  if (!res.ok) {
     const text = await res.text();
     throw new Error(`Alpaca data error ${res.status}: ${text}`);
   }


### PR DESCRIPTION
## Summary
- add environment helpers and broker credential loading
- reuse helpers in execution packages for consistent env handling

## Testing
- `pnpm lint` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm test` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68a00a7f3a48832494390c9e6e181a49