### PR TITLE
refactor: use Deno.serve for edge functions

### DIFF
--- a/supabase/functions/kill-switch/index.ts
+++ b/supabase/functions/kill-switch/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "@supabase/supabase-js";
 
 async function alpacaFetch(path: string, opts: RequestInit = {}) {
@@ -17,7 +16,7 @@ async function alpacaFetch(path: string, opts: RequestInit = {}) {
   return res.json();
 }
 
-serve(async (_req) => {
+Deno.serve(async (_req) => {
   const url = Deno.env.get('SUPABASE_URL');
   const key = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
   if (!url || !key) {

--- a/supabase/functions/monitor-open-trades/index.ts
+++ b/supabase/functions/monitor-open-trades/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "@supabase/supabase-js";
 import { insertAuditLog } from "../_shared/audit.ts";
 import {
@@ -26,7 +25,7 @@ async function fetchLatestPrice(symbol: string) {
  *
  * Checks TTL, stop/target hits, max loss (1R), risk % caps, and manages trailing stops.
  */
-serve(async (_req) => {
+Deno.serve(async (_req) => {
   const url = Deno.env.get("SUPABASE_URL");
   const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
   if (!url || !key) {

--- a/supabase/functions/research-run/index.ts
+++ b/supabase/functions/research-run/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { fetchPaperBars, Bar } from "../_shared/execution.ts";
 import { sma, rsi, detectRegime } from "../_shared/strategy.ts";
@@ -77,6 +76,11 @@ async function generateAnalysis(
         `Regime ${regime}; SMA20 ${smaVal.toFixed(2)}; RSI14 ${rsiVal.toFixed(2)}. ` +
         `Provide a brief summary and highlight key risks. ` +
         `Respond in JSON format with fields "summary" and "risks".`;
+      console.log("Calling Azure OpenAI", {
+        endpoint: azureEndpoint,
+        deployment: azureDeployment,
+        symbol,
+      });
       const res = await fetch(
         `${azureEndpoint}/openai/deployments/${azureDeployment}/chat/completions?api-version=${azureApiVersion}`,
         {
@@ -98,6 +102,7 @@ async function generateAnalysis(
           }),
         },
       );
+      console.log("Azure OpenAI response status", res.status);
       const json = await res.json();
       const content = json.choices?.[0]?.message?.content;
       if (content) {
@@ -158,7 +163,7 @@ async function generateAnalysis(
  * - `model_id`  Optional model identifier (for audit)
  * - `model_version` Optional model version (for audit)
  */
-serve(async (req) => {
+Deno.serve(async (req) => {
   const { searchParams } = new URL(req.url);
   const timeframe = searchParams.get("timeframe") ?? "1D";
   const modelId = searchParams.get("model_id") ?? undefined;


### PR DESCRIPTION
## Summary
- remove std/http/server imports from edge functions
- use built-in `Deno.serve` for research, monitoring, and kill-switch functions
- add logging around Azure OpenAI requests in the research-run function

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.14.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b84b0f908324b21ccbd4bd0a6dec