### PR TITLE
Handle insert errors in research-run

### DIFF
--- a/supabase/functions/research-run/index.ts
+++ b/supabase/functions/research-run/index.ts
@@ -254,7 +254,12 @@ Deno.serve(async (req) => {
           .select("id")
           .single();
 
-        if (!error && data) {
+        if (error) {
+          console.error("insert trade_opportunities failed for", symbol, error);
+          throw error;
+        }
+
+        if (data) {
           results.push({ symbol, id: data.id });
 
           await insertAuditLog(supabase, {


### PR DESCRIPTION
## Summary
- Log and rethrow `trade_opportunities` insert errors so failures aren't silent